### PR TITLE
Add the clustershell roster to heist

### DIFF
--- a/heist/roster/clustershell.py
+++ b/heist/roster/clustershell.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+'''
+This roster resolves hostname in a pdsh/clustershell style.
+
+:depends: clustershell, https://github.com/cea-hpc/clustershell
+
+When you want to use host globs for target matching, use ``--roster clustershell``. For example:
+
+.. code-block:: bash
+
+    heist --roster clustershell --target 'server_[1-10,21-30],test_server[5,7,9]'
+
+'''
+
+
+# Import python libs
+import asyncio
+import ipaddress
+import logging
+import socket
+from typing import Any, Dict
+
+# Import 3rd-party libs
+from ClusterShell.NodeSet import NodeSet
+
+log = logging.getLogger(__name__)
+
+async def read(hub) -> Dict[str, Any]:
+    '''
+    Resolve hostname in a clustershell style
+    and query the ports for SSH
+    '''
+    ret = {}
+    tgt = hub.OPT['heist'].get('target')
+    if not tgt:
+        log.critical('Need to define a target for the scan roster')
+        return ret
+    ports = hub.OPT['heist']['ssh_scan_ports']
+    if not isinstance(ports, list):
+        # Comma-separate list of integers
+        ports = list(map(int, str(ports).split(',')))
+
+    hosts = list(NodeSet(tgt))
+    host_addrs = dict([(h, socket.gethostbyname(h)) for h in hosts])
+
+    for host, addr in host_addrs.items():
+        addr = ipaddress.ip_address(addr)
+        for port in ports:
+            log.debug(f'Scanning host: {addr} on port: {port}')
+            try:
+                if addr.version == 4:
+                    fam = socket.AF_INET
+                elif addr.version == 6:
+                    fam = socket.AF_INET6
+
+                addr = addr.exploded
+                reader, writer = await asyncio.open_connection(
+                    addr, port, family=fam)
+                data = await reader.read(100)
+                if 'ssh' not in data.decode().lower():
+                    log.critical(f'Connection successful to {addr} '
+                                 f'but SSH information not returned.'
+                                 f'Port {port} might not be an SSH port.')
+                ret[addr] = ({'host': addr, 'port': port})
+                writer.close()
+                await writer.wait_closed()
+            except ConnectionRefusedError:
+                log.critical(f'Not able to connect to host: {addr} on port: {port}')
+                pass
+    return ret

--- a/tests/unit/roster/conftest.py
+++ b/tests/unit/roster/conftest.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+'''
+    tests.unit.roster.conftest
+    ~~~~~~~~~~~~~~
+
+    Setup fixtures specifically for the roster unit tests
+'''
+
+# Import local libs
+import tests.helpers.mock_hub as helpers
+
+# Import 3rd-party libs
+import pytest
+
+@pytest.fixture
+def mock_hub():
+    '''
+    mock the needed subs for the flat roster tests
+    '''
+    # A fixture is required for asynchronous tests to access a mock_hub
+    return helpers.mock_hub(subs=['heist.heist', 'heist.roster', 'rend', 'output'])

--- a/tests/unit/roster/test_clustershell.py
+++ b/tests/unit/roster/test_clustershell.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+'''
+    unit tests for the clustershell roster
+'''
+
+# Import python libs
+import socket
+
+# Import local libs
+import heist.roster.clustershell
+
+# Import 3rd-party libs
+import pytest
+
+
+class TestClustershellRoster:
+    '''
+    unit tests for heist.roster.clustershell
+    '''
+    @pytest.mark.asyncio
+    async def test_read(self, mock_hub):
+        '''
+        test clustershell roster against port 22 localhost
+        '''
+        # Setup
+        target = socket.gethostname()
+        addr = socket.gethostbyname(target)
+        mock_hub.OPT = {'heist': {'target': target,
+                                  'ssh_scan_ports': [22]}}
+
+        # Execute
+        ret = await heist.roster.clustershell.read(mock_hub)
+
+        assert ret[addr]['host'] == addr
+        assert ret[addr]['port'] == 22
+
+    @pytest.mark.asyncio
+    async def test_clustershell_non_ssh_port(self, mock_hub):
+        '''
+        test clustershell roster against port not running ssh
+        '''
+        # Setup
+        target = socket.gethostname()
+
+        target = '127.0.0.1'
+        mock_hub.OPT = {'heist': {'target': target,
+                                  'ssh_scan_ports': [22222]}}
+
+        # Execute
+        ret = await heist.roster.clustershell.read(mock_hub)
+
+        assert ret == {}

--- a/tests/unit/roster/test_flat.py
+++ b/tests/unit/roster/test_flat.py
@@ -7,7 +7,6 @@ from typing import Tuple
 
 # Import local libs
 import heist.roster.flat
-import tests.helpers.mock_hub as helpers
 import pop.hub
 from pop.utils import testing
 
@@ -23,15 +22,6 @@ host_str_id:
 host_num_id:
   id: 1234
 '''
-
-
-@pytest.fixture
-def mock_hub():
-    '''
-    mock the needed subs for the flat roster tests
-    '''
-    # A fixture is required for asynchronous tests to access a mock_hub
-    return helpers.mock_hub(subs=['heist.heist', 'heist.roster', 'rend', 'output'])
 
 @pytest.fixture(scope='function')
 def hub():

--- a/tests/unit/roster/test_scan.py
+++ b/tests/unit/roster/test_scan.py
@@ -2,19 +2,10 @@
 
 # Import local libs
 import heist.roster.scan
-import tests.helpers.mock_hub as helpers
 
 # Import 3rd-party libs
 import pytest
 
-
-@pytest.fixture
-def mock_hub():
-    '''
-    mock the needed subs for the flat roster tests
-    '''
-    # A fixture is required for asynchronous tests to access a mock_hub
-    return helpers.mock_hub(subs=['heist.heist', 'heist.roster'])
 
 class TestScanRoster:
     '''

--- a/tests/unit/tunnel/test_asyncssh_tunnel.py
+++ b/tests/unit/tunnel/test_asyncssh_tunnel.py
@@ -34,7 +34,7 @@ class TestAsyncSSH:
         Test getting option from autodetect of target and config aren't available
         '''
         mock_hub = helpers.mock_hub()
-        mock_hub.OPT = {'heist': {}}
+        mock_hub.OPT = {'heist': {'roster_defaults': {}}}
         target = {}
         result = asyncssh_tunnel._get_asyncssh_opt(mock_hub, target=target, option='username', default='default')
         assert result == 'autodetect'


### PR DESCRIPTION
Part of porting over ssh rosters from salt-ssh: https://github.com/saltstack/heist/issues/17