### PR TITLE
pytest fixes

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 asynctest>=0.13.0
+jinja2>=2.10.3
 mock>=3.0.5
 M2Crypto>=0.35.2
 pidfile>=0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ asyncssh>=1.18.0
 pop>=7.3.0
 pyyaml>=5.1.2
 rend>=2.0.0
+ClusterShell>=1.8.1

--- a/tests/helpers/mock_hub.py
+++ b/tests/helpers/mock_hub.py
@@ -1,9 +1,9 @@
 # import Python libs
 import sys
 from typing import List
+import unittest.mock as mock
 
 # Import 3rd-party libs
-import mock
 import pop.hub
 import pop.mods.pop.testing as testing
 


### PR DESCRIPTION
Use unittest.mock instead of separate mock library

Add ClusterShell package to requirements.txt