### PR TITLE
Set executable bit and execute with sudo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,8 @@ Now you can just run it!
 
 .. code-block:: bash
 
-    ./salt master
+    chmod +x salt
+    sudo ./salt master
 
 Now you have a running Salt Master to control your minions!
 


### PR DESCRIPTION
* After downloading the binary, there is no executable bit set.
* Executing ./salt master fails at least for me because of insufficient permissions for /etc/salt/pki/master.